### PR TITLE
Enable reasoning models for planning agents

### DIFF
--- a/conf.yaml.example
+++ b/conf.yaml.example
@@ -7,3 +7,10 @@ BASIC_MODEL:
   base_url: https://ark.cn-beijing.volces.com/api/v3
   model: "doubao-1-5-pro-32k-250115"
   api_key: xxxx
+
+# An example configuration for reasoning-capable models
+# Replace with your reasoning model details or remove if not used
+REASONING_MODEL:
+  base_url: https://api.openai.com/v1
+  model: "gpt-4o"
+  api_key: xxxx

--- a/docs/configuration_guide.md
+++ b/docs/configuration_guide.md
@@ -11,11 +11,11 @@ cp conf.yaml.example conf.yaml
 
 ## Which models does DeerFlow support?
 
-In DeerFlow, currently we only support non-reasoning models, which means models like OpenAI's o1/o3 or DeepSeek's R1 are not supported yet, but we will add support for them in the future.
+DeerFlow supports both standard chat models and reasoning models. Reasoning models such as OpenAI's `o1`/`o3` or DeepSeek's `r1` can now be configured using the `REASONING_MODEL` section in `conf.yaml`.
 
 ### Supported Models
 
-`doubao-1.5-pro-32k-250115`, `gpt-4o`, `qwen-max-latest`, `gemini-2.0-flash`, `deepseek-v3`, and theoretically any other non-reasoning chat models that implement the OpenAI API specification.
+`doubao-1.5-pro-32k-250115`, `gpt-4o`, `qwen-max-latest`, `gemini-2.0-flash`, `deepseek-v3`, and theoretically any other chat model that implements the OpenAI API specification. Reasoning-capable models should be configured under `REASONING_MODEL`.
 
 > [!NOTE]
 > The Deep Research process requires the model to have a **longer context window**, which is not supported by all models.

--- a/src/config/agents.py
+++ b/src/config/agents.py
@@ -9,7 +9,7 @@ LLMType = Literal["basic", "reasoning", "vision"]
 # Define agent-LLM mapping
 AGENT_LLM_MAP: dict[str, LLMType] = {
     "coordinator": "basic",
-    "planner": "basic",
+    "planner": "reasoning",
     "researcher": "basic",
     "coder": "basic",
     "reporter": "basic",

--- a/src/graph/nodes.py
+++ b/src/graph/nodes.py
@@ -80,7 +80,10 @@ def orchestrator_node(state: State) -> Command[Literal["planner"]]:
     tasks = state.get("tasks", [])
     if not tasks:
         task = {"agent": "planner", "task": state["messages"][-1].content}
-        _orchestrator.assign(task["agent"], task["task"])
+        assignment = _orchestrator.assign(
+            task["agent"], task["task"], AGENT_LLM_MAP.get("planner")
+        )
+        task.update({"llm_type": assignment["llm_type"]})
         tasks.append(task)
     return Command(update={"tasks": tasks}, goto="planner")
 
@@ -110,20 +113,17 @@ def planner_node(
             }
         ]
 
-    if AGENT_LLM_MAP["planner"] == "basic":
-        llm = get_llm_by_type(AGENT_LLM_MAP["planner"]).with_structured_output(
-            Plan,
-            method="json_mode",
-        )
-    else:
-        llm = get_llm_by_type(AGENT_LLM_MAP["planner"])
+    planner_llm_type = AGENT_LLM_MAP["planner"]
+    llm = get_llm_by_type(planner_llm_type)
+    if planner_llm_type in ("basic", "reasoning"):
+        llm = llm.with_structured_output(Plan, method="json_mode")
 
     # if the plan iterations is greater than the max plan iterations, return the reporter node
     if plan_iterations >= configurable.max_plan_iterations:
         return Command(goto="reporter")
 
     full_response = ""
-    if AGENT_LLM_MAP["planner"] == "basic":
+    if planner_llm_type in ("basic", "reasoning"):
         response = llm.invoke(messages)
         full_response = response.model_dump_json(indent=4, exclude_none=True)
     else:

--- a/src/hubs/orchestrator.py
+++ b/src/hubs/orchestrator.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from src.config.agents import AGENT_LLM_MAP
+
 
 class Orchestrator:
     """Assign tasks to agents and keeps track of the assignments."""
@@ -11,8 +13,24 @@ class Orchestrator:
     def __init__(self) -> None:
         self.task_queue: list[dict[str, Any]] = []
 
-    def assign(self, agent_name: str, task: str) -> dict[str, Any]:
-        """Assign a task to an agent."""
-        assignment = {"agent": agent_name, "task": task}
+    def assign(
+        self, agent_name: str, task: str, llm_type: str | None = None
+    ) -> dict[str, Any]:
+        """Assign a task to an agent.
+
+        Parameters
+        ----------
+        agent_name : str
+            Name of the agent the task is assigned to.
+        task : str
+            The task description.
+        llm_type : str | None, optional
+            The LLM type powering this agent. If ``None`` it is looked up
+            in :data:`AGENT_LLM_MAP` and defaults to ``"basic"`` when the
+            agent name is not present.
+        """
+
+        resolved_llm_type = llm_type or AGENT_LLM_MAP.get(agent_name, "basic")
+        assignment = {"agent": agent_name, "task": task, "llm_type": resolved_llm_type}
         self.task_queue.append(assignment)
         return assignment

--- a/tests/unit/test_hubs.py
+++ b/tests/unit/test_hubs.py
@@ -1,4 +1,5 @@
 from src.hubs import Bulletin, Secretary, Orchestrator
+from src.config.agents import AGENT_LLM_MAP
 
 
 def test_bulletin_post_and_history():
@@ -21,3 +22,4 @@ def test_orchestrator_assign():
     assert task in orchestrator.task_queue
     assert task["agent"] == "agent"
     assert task["task"] == "do work"
+    assert task["llm_type"] == AGENT_LLM_MAP.get("agent", "basic")


### PR DESCRIPTION
## Summary
- support reasoning model configuration in `conf.yaml.example`
- allow orchestrator to record each task's LLM type
- update orchestrator node to include llm_type info
- use structured output when planner runs in reasoning mode
- default planner to reasoning model
- revise docs accordingly
- update unit test

## Testing
- `black --check --preview src/config/agents.py src/graph/nodes.py src/hubs/orchestrator.py tests/unit/test_hubs.py`
- `make lint` *(fails: No route to host)*
- `make format` *(fails: No route to host)*
- `make test` *(fails: No route to host)*